### PR TITLE
feat: Add BlogContent CRUD operations with routes, controller, model,…

### DIFF
--- a/client/src/services/blogContent.service.ts
+++ b/client/src/services/blogContent.service.ts
@@ -1,0 +1,37 @@
+import api from "./main.service";
+  
+  export interface BlogContent {
+      id: string;
+    orderNumber: number;
+  }
+  
+  export function blogContentService() {
+      const createBlogContent = async (blogContent: Omit<BlogContent, "id">) => {
+          return await api.post("/blogContents", blogContent);
+      };
+
+      const getAllBlogContents = async () => {
+          return await api.get("/blogContents");
+      };
+
+      const getBlogContentById = async (id: string) => {
+          return await api.get("/blogContents/" + id);
+      };
+
+      const updateBlogContent = async (id: string, blogContent: Omit<BlogContent, "id">) => {
+          return await api.patch("/blogContents/" + id, blogContent);
+      };
+
+      const deleteBlogContent = async (id: string) => {
+          return await api.delete("/blogContents/" + id);
+      };
+  
+      return {
+          createBlogContent,
+        getAllBlogContents,
+        getBlogContentById,
+        updateBlogContent,
+        deleteBlogContent
+      };
+  }
+  

--- a/server/src/controllers/blogContent.controller.ts
+++ b/server/src/controllers/blogContent.controller.ts
@@ -1,0 +1,86 @@
+
+  import BlogContent from '../models/blogContent.model';
+  import { blogContentSchema } from '../schemas/blogContent.schema';
+  import { validateSchema } from '../utils/validateSchema';
+  
+  
+  export async function createBlogContent(req:any, res:any) {
+    try {
+      const schema = blogContentSchema().create();
+      validateSchema(schema, req.body);
+  
+      const newBlogContent = await BlogContent.create(req.body);
+      res.status(201).json(newBlogContent);
+    } catch (error) {
+        res.status(400).json({ error: (error instanceof Error) ? error.message : 'An unknown error occurred' });
+
+    }
+  }
+
+
+  export async function getAllBlogContents(req:any, res:any) {
+    try {
+      const items = await BlogContent.findAll();
+      res.status(200).json(items);
+    } catch (error) {
+        res.status(400).json({ error: (error instanceof Error) ? error.message : 'An unknown error occurred' });
+
+    }
+  }
+
+
+  export async function getBlogContentById(req:any, res:any) {
+    try {
+      const schema = blogContentSchema().readById();
+      validateSchema(schema, req.body);
+  
+      const item = await BlogContent.findByPk(req.params.id);
+      if (!item) {
+        return res.status(404).json({ error: 'BlogContent not found' });
+      }
+  
+      res.status(200).json(item);
+    } catch (error) {
+        res.status(400).json({ error: (error instanceof Error) ? error.message : 'An unknown error occurred' });
+
+    }
+  }
+
+
+  export async function updateBlogContent(req:any, res:any) {
+    try {
+      const schema = blogContentSchema().update();
+      validateSchema(schema, req.body);
+  
+      const item = await BlogContent.findByPk(req.body.id);
+      if (!item) {
+        return res.status(404).json({ error: 'BlogContent not found' });
+      }
+  
+      await item.update(req.body);
+      res.status(200).json(item);
+    } catch (error) {
+        res.status(400).json({ error: (error instanceof Error) ? error.message : 'An unknown error occurred' });
+
+    }
+  }
+
+
+  export async function deleteBlogContent(req:any, res:any) {
+    try {
+      const schema = blogContentSchema().destroy();
+      validateSchema(schema, req.body);
+  
+      const item = await BlogContent.findByPk(req.params.id);
+      if (!item) {
+        return res.status(404).json({ error: 'BlogContent not found' });
+      }
+  
+      await item.destroy();
+      res.status(200).json({ message: 'BlogContent deleted successfully' });
+    } catch (error) {
+        res.status(400).json({ error: (error instanceof Error) ? error.message : 'An unknown error occurred' });
+
+    }
+  }
+  

--- a/server/src/models/blogContent.model.ts
+++ b/server/src/models/blogContent.model.ts
@@ -1,0 +1,83 @@
+
+import { sequelize } from "../config/database";
+import { DataTypes, Model } from "sequelize";
+import Blog from "./blog.model";
+import Content from "./content.model";
+
+export class BlogContent extends Model {
+  public id!: number;
+  public blogId!: string;
+  public contentId!: string;
+  public orderNumber!: number;
+
+  public readonly createdAt!: Date;
+  public readonly updatedAt!: Date;
+}
+
+BlogContent.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+      allowNull: false,
+    },
+    blogId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      references: {
+        model: Blog,
+        key: "id",
+      },
+      validate: {
+        notEmpty: true,
+        isUUID: 4,
+      },
+    },
+    contentId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      references: {
+        model: Content,
+        key: "id",
+      },
+      validate: {
+        notEmpty: true,
+        isUUID: 4,
+      },
+    },
+    
+    orderNumber: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+  },
+  {
+    sequelize,
+    modelName: "BlogContent",
+    tableName: "blogcontents",
+    timestamps: true,
+  }
+);
+
+
+Blog.hasMany(BlogContent, {
+  foreignKey: "blogId",
+  as: "blogcontents",
+});
+BlogContent.belongsTo(Blog, {
+  foreignKey: "blogId",
+  as: "blog",
+});
+
+Content.hasMany(BlogContent, {
+  foreignKey: "contentId",
+  as: "blogcontents",
+});
+BlogContent.belongsTo(Content, {
+  foreignKey: "contentId",
+  as: "content",
+});
+
+
+export default BlogContent;

--- a/server/src/routes/blogContent.routes.ts
+++ b/server/src/routes/blogContent.routes.ts
@@ -1,0 +1,19 @@
+
+  import { createBlogContent,
+  getAllBlogContents,
+  getBlogContentById,
+  updateBlogContent,
+  deleteBlogContent } from "../controllers/blogContent.controller";
+  import { Router } from "express";
+import { isAuthenticated } from "../middlewares/isAuthenticated";
+  const blogContentRouter = Router();
+  
+  // Routes
+  blogContentRouter.post("/",isAuthenticated, createBlogContent);
+blogContentRouter.get("/", getAllBlogContents);
+blogContentRouter.get("/:id", getBlogContentById);
+blogContentRouter.patch("/",isAuthenticated, updateBlogContent);
+blogContentRouter.delete("/:id",isAuthenticated, deleteBlogContent);
+  
+  export default blogContentRouter;
+  

--- a/server/src/routes/main.routes.ts
+++ b/server/src/routes/main.routes.ts
@@ -6,6 +6,7 @@ import blogRouter from "./blog.routes";
 import pageRouter from "./page.routes";
 import contentRouter from "./content.routes";
 import pageContentRouter from "./pageContent.routes";
+import blogContentRouter from "./blogContent.routes";
 
 
 const mainRouter = Router();
@@ -24,4 +25,5 @@ mainRouter.use("/api/blogs", blogRouter);
 mainRouter.use("/api/pages", pageRouter);
 mainRouter.use("/api/contents", contentRouter);
 mainRouter.use("/api/pageContents", pageContentRouter);
+mainRouter.use("/api/blogContents", blogContentRouter);
 export default mainRouter;

--- a/server/src/schemas/blogContent.schema.ts
+++ b/server/src/schemas/blogContent.schema.ts
@@ -1,0 +1,91 @@
+
+  export function blogContentSchema() {
+  
+  
+  function create() {
+    return {
+      type: 'object',
+      properties: {
+        blogId: {
+          type: 'string',
+          format: 'uuid',
+        },
+        contentId: {
+          type: 'string',
+          format: 'uuid',
+        },
+        orderNumber: {
+          type: 'integer',
+          minimum: 1, // Minimum value for orderNumber
+          default: 1, // Default value for orderNumber
+        },
+      },
+      required: [
+        'blogId',
+        'contentId',
+      ],
+      additionalProperties: false,
+    };
+  }
+  
+
+
+  function readAll() {
+    return {
+    };
+  }
+  
+
+
+  function readById() {
+    return {
+    };
+  }
+  
+
+
+  function update() {
+    return {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          format: 'uuid',
+        },
+        blogId: {
+          type: 'string',
+          format: 'uuid',
+        },
+        contentId: {
+          type: 'string',
+          format: 'uuid',
+        },
+        orderNumber: {
+          type: 'integer',
+          minimum: 1, // Minimum value for orderNumber
+          default: 1, // Default value for orderNumber
+        },
+      },
+      additionalProperties: false,
+    };
+  }
+  
+
+
+  function destroy() {
+    return {
+      
+    };
+  }
+  
+  
+      return {
+          create,
+        readAll,
+        readById,
+        update,
+        destroy
+      };
+  }
+  
+  

--- a/server/src/specs/fixtures/blogContent.fixture.ts
+++ b/server/src/specs/fixtures/blogContent.fixture.ts
@@ -1,0 +1,34 @@
+
+  import BlogContent from "../../models/blogContent.model";
+  import { createBlogFixture } from "./blog.fixture";
+import { createContentFixture } from "./content.fixture";
+  
+  interface BlogContentOverrides {
+    blogId?: string;
+  contentId?: string;
+    orderNumber?: number; 
+  }
+  
+  export const createBlogContentFixture = async (overrides: BlogContentOverrides = {}) => {
+    if (!overrides.blogId) {
+      const blog = await createBlogFixture();
+      overrides.blogId = blog.id.toString();
+    }
+
+    if (!overrides.contentId) {
+      const content = await createContentFixture();
+      overrides.contentId = content.id.toString();
+    }
+    if (overrides.orderNumber === undefined) {
+      overrides.orderNumber = 1; // Default order number
+    }
+  
+    const blogContent = await BlogContent.create({
+      blogId: overrides.blogId,
+      contentId: overrides.contentId,
+      orderNumber: overrides.orderNumber,
+    });
+  
+    return blogContent;
+  };
+  

--- a/server/src/specs/routes/blogContent.routes.test.ts
+++ b/server/src/specs/routes/blogContent.routes.test.ts
@@ -1,0 +1,127 @@
+
+  import app from "../../server";
+  import request from "supertest";
+  import { preTestSetup } from "../../utils/pre-test";
+  import { faker } from "@faker-js/faker";
+  import { createBlogContentFixture } from "../fixtures/blogContent.fixture";
+  import { createBlogFixture } from "../fixtures/blog.fixture";
+import { createContentFixture } from "../fixtures/content.fixture";
+import { createUserFixture } from "../fixtures/user.fixture";
+  
+  describe("BlogContent Routes", () => {
+    
+  it("should create a new blogContent", async () => {
+      await preTestSetup();
+  
+      const blog = await createBlogFixture();
+    const content = await createContentFixture();
+      const sudoUser = (await createUserFixture({ role: "sudo" }))
+      const login = await request(app)
+        .post("/api/users/login")
+        .send({
+          username: sudoUser.username,
+          password: sudoUser.nonHashedPassword,
+        })
+        .expect(200);
+      const cookie = login.headers["set-cookie"][0];
+  
+      const data = {
+        blogId: blog.id.toString(),
+      contentId: content.id.toString(),
+        orderNumber: 1, 
+      };
+  
+      const response = await request(app)
+        .post("/api/blogContents")
+        .send(data)
+        .set("Cookie", cookie)
+        .expect(201);
+  
+      expect(response.body).toHaveProperty("id");
+      expect(response.body).toHaveProperty("blogId");
+  });
+
+
+  it("should get all blogContents", async () => {
+      await preTestSetup();
+      await createBlogContentFixture();
+  
+      const response = await request(app)
+        .get("/api/blogContents")
+        .expect(200);
+  
+      expect(Array.isArray(response.body)).toBe(true);
+  });
+
+
+  it("should get blogContent by id", async () => {
+      await preTestSetup();
+      const blogContent = await createBlogContentFixture();
+  
+      const response = await request(app)
+        .get("/api/blogContents/" + blogContent.id)
+        .expect(200);
+  
+      expect(response.body).toHaveProperty("id");
+      expect(response.body.id).toBe(blogContent.id);
+  });
+
+
+  it("should update blogContent", async () => {
+      await preTestSetup();
+      const blogContent = await createBlogContentFixture();
+  
+      const blog = await createBlogFixture();
+    const content = await createContentFixture();
+    const sudoUser = (await createUserFixture({ role: "sudo" }))
+      const login = await request(app)
+        .post("/api/users/login")
+        .send({   
+          username: sudoUser.username,
+          password: sudoUser.nonHashedPassword,
+        })
+        .expect(200);
+      const cookie = login.headers["set-cookie"][0];
+  
+      const updateData = {
+        id: blogContent.id,
+        blogId: blog.id.toString(),
+      contentId: content.id.toString(),
+        orderNumber: 2,
+      };
+  
+      const response = await request(app)
+        .patch("/api/blogContents")
+        .send(updateData)
+        .set("Cookie", cookie)
+        .expect(200);
+  
+      expect(response.body).toHaveProperty("id");
+      expect(response.body.id).toBe(blogContent.id);
+  });
+
+
+  it("should delete blogContent", async () => {
+      await preTestSetup();
+      const blogContent = await createBlogContentFixture();
+      const sudoUser = (await createUserFixture({ role: "sudo" }))
+      const login = await request(app)
+        .post("/api/users/login")
+        .send({
+          username: sudoUser.username,
+          password: sudoUser.nonHashedPassword,
+        })
+        .expect(200);
+      const cookie = login.headers["set-cookie"][0];
+  
+      const response = await request(app)
+        .delete("/api/blogContents/" + blogContent.id)
+        .send({ id: blogContent.id })
+        .set("Cookie", cookie)
+        .expect(200);
+  
+      expect(response.body).toHaveProperty("message");
+      expect(response.body.message).toBe("BlogContent deleted successfully");
+  });
+  });
+  


### PR DESCRIPTION
This pull request introduces a new `BlogContent` feature, which integrates both the client and server sides of the application to manage the relationship between blogs and their associated content. The most important changes include the addition of a service on the client side, a controller and model on the server side, routes for CRUD operations, and corresponding schema validation and test cases.

### Client-side implementation:

* **BlogContent Service**: Added `blogContentService` in `client/src/services/blogContent.service.ts` to handle CRUD operations for `BlogContent` entities, including methods like `createBlogContent`, `getAllBlogContents`, `getBlogContentById`, `updateBlogContent`, and `deleteBlogContent`.

### Server-side implementation:

#### Core functionality:

* **BlogContent Model**: Created `BlogContent` model in `server/src/models/blogContent.model.ts` with fields `id`, `blogId`, `contentId`, and `orderNumber`. Established relationships with existing `Blog` and `Content` models.
* **BlogContent Controller**: Implemented CRUD operations in `server/src/controllers/blogContent.controller.ts` to manage `BlogContent` entities, including validation using schemas.

#### Routing and validation:

* **Routes**: Added `blogContentRouter` in `server/src/routes/blogContent.routes.ts` for API endpoints (e.g., `/api/blogContents`) and integrated it into the main router in `server/src/routes/main.routes.ts`. [[1]](diffhunk://#diff-0425747c71a12e1661c507571c2fd471325d8ee7bc6cb44cb5e07b3941b178e0R1-R19) [[2]](diffhunk://#diff-6c4b4e04bebacd0cc95967b81905270fba96eb6ca34f1356d24dcf098cd52f68R28)
* **Schema Validation**: Defined `blogContentSchema` in `server/src/schemas/blogContent.schema.ts` for validating input data during CRUD operations.

#### Testing:

* **Fixtures and Tests**: Added `createBlogContentFixture` in `server/src/specs/fixtures/blogContent.fixture.ts` for test data and comprehensive tests for routes in `server/src/specs/routes/blogContent.routes.test.ts`. [[1]](diffhunk://#diff-cde24d621daefa6c95c692534f8bc2fdacb407e28af1db687db6880afba71ce3R1-R34) [[2]](diffhunk://#diff-9fa302aeef84bcab8287299dc380d6c5c5ff8325018df5c47185e08389fc4ec4R1-R127)