### PR TITLE
feat: Update models, services, schemas, and fixtures to support multi…

### DIFF
--- a/client/src/services/album.service.ts
+++ b/client/src/services/album.service.ts
@@ -2,7 +2,8 @@ import api from "./main.service";
   
   export interface Album {
       id: string;
-    title: string;
+    titleFr: string;
+    titleEn: string;
   }
   
   export function albumService() {

--- a/client/src/services/blog.service.ts
+++ b/client/src/services/blog.service.ts
@@ -2,7 +2,8 @@ import api from "./main.service";
   
   export interface Blog {
       id: string;
-    title: string;
+    titleFr: string;
+    titleEn: string;
     isPublished: boolean;
   }
   

--- a/client/src/services/content.service.ts
+++ b/client/src/services/content.service.ts
@@ -2,7 +2,8 @@ import api from "./main.service";
   
   export interface Content {
       id: string;
-    content: string;
+    contentFr: string;
+    contentEn: string;
     isPublished: boolean;
   }
   

--- a/client/src/services/page.service.ts
+++ b/client/src/services/page.service.ts
@@ -2,7 +2,8 @@ import api from "./main.service";
   
   export interface Page {
       id: string;
-    title: string;
+    titleFr: string;
+    titleEn: string;
     isPublished: boolean;
   }
   

--- a/client/src/services/picture.service.ts
+++ b/client/src/services/picture.service.ts
@@ -3,6 +3,8 @@ import api from "./main.service";
   export interface Picture {
       id: string;
     url: string;
+    descriptionFr: string;
+    descriptionEn: string;
     isPublished: boolean;
   }
   

--- a/server/src/models/album.model.ts
+++ b/server/src/models/album.model.ts
@@ -6,7 +6,8 @@ import { DataTypes, Model } from "sequelize";
 export class Album extends Model {
   public id!: number;
 
-  public title!: string;
+  public titleFr!: string;
+  public titleEn!: string;
   public readonly isPublished!: boolean;
 
   public readonly createdAt!: Date;
@@ -22,7 +23,11 @@ Album.init(
       allowNull: false,
     },
     
-    title: {
+    titleFr: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    titleEn: {
       type: DataTypes.STRING,
       allowNull: true,
     },

--- a/server/src/models/blog.model.ts
+++ b/server/src/models/blog.model.ts
@@ -6,7 +6,8 @@ import { DataTypes, Model } from "sequelize";
 export class Blog extends Model {
   public id!: number;
 
-  public title!: string;
+  public titleFr!: string;
+  public titleEn!: string;
   public isPublished!: boolean;
 
   public readonly createdAt!: Date;
@@ -22,7 +23,11 @@ Blog.init(
       allowNull: false,
     },
     
-    title: {
+    titleFr: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    titleEn: {
       type: DataTypes.STRING,
       allowNull: true,
     },

--- a/server/src/models/content.model.ts
+++ b/server/src/models/content.model.ts
@@ -6,7 +6,8 @@ import { DataTypes, Model } from "sequelize";
 export class Content extends Model {
   public id!: number;
 
-  public content!: string;
+  public contentFr!: string;
+  public contentEn!: string;
   public isPublished!: boolean;
 
   public readonly createdAt!: Date;
@@ -22,7 +23,11 @@ Content.init(
       allowNull: false,
     },
     
-    content: {
+    contentFr: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    contentEn: {
       type: DataTypes.TEXT,
       allowNull: true,
     },

--- a/server/src/models/page.model.ts
+++ b/server/src/models/page.model.ts
@@ -6,7 +6,8 @@ import { DataTypes, Model } from "sequelize";
 export class Page extends Model {
   public id!: number;
 
-  public title!: string;
+  public titleFr!: string;
+  public titleEn!: string;
   public isPublished!: boolean;
 
   public readonly createdAt!: Date;
@@ -22,7 +23,11 @@ Page.init(
       allowNull: false,
     },
     
-    title: {
+    titleFr: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    titleEn: {
       type: DataTypes.STRING,
       allowNull: true,
     },

--- a/server/src/models/picture.model.ts
+++ b/server/src/models/picture.model.ts
@@ -8,7 +8,8 @@ export class Picture extends Model {
   public albumId!: string;
   public url!: string;
   public isPublished!: boolean;
-  public description!: string;
+  public descriptionFr!: string;
+  public descriptionEn!: string;
 
   public readonly createdAt!: Date;
   public readonly updatedAt!: Date;
@@ -43,7 +44,14 @@ Picture.init(
       type: DataTypes.BOOLEAN,
       allowNull: true,
     },
-    description: {
+    descriptionFr: {
+      type: DataTypes.STRING(500),
+      allowNull: true,
+      validate: {
+        len: [0, 500],
+      },
+    },
+    descriptionEn: {
       type: DataTypes.STRING(500),
       allowNull: true,
       validate: {

--- a/server/src/schemas/album.schema.ts
+++ b/server/src/schemas/album.schema.ts
@@ -7,7 +7,12 @@ import { title } from "process";
     return {
       type: 'object',
       properties: {
-        title: {
+        titleFr: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 255,
+        },
+        titleEn: {
           type: 'string',
           minLength: 1,
           maxLength: 255,
@@ -18,7 +23,8 @@ import { title } from "process";
         }
       },
       required: [
-        'title'
+        'titleFr',
+        'titleEn'
       ],
       additionalProperties: false,
     };
@@ -53,7 +59,12 @@ import { title } from "process";
           type: 'string',
           format: 'uuid',
         },
-        title: {
+        titleFr: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 255,
+        },
+        titleEn: {
           type: 'string',
           minLength: 1,
           maxLength: 255,

--- a/server/src/schemas/blog.schema.ts
+++ b/server/src/schemas/blog.schema.ts
@@ -6,7 +6,12 @@
     return {
       type: 'object',
       properties: {
-        title: {
+        titleFr: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 255,
+        },
+        titleEn: {
           type: 'string',
           minLength: 1,
           maxLength: 255,
@@ -17,7 +22,8 @@
         }
       },
       required: [
-        'title'
+        'titleFr',
+        'titleEn'
       ],
       additionalProperties: false,
     };
@@ -45,7 +51,12 @@
           type: 'string',
           format: 'uuid',
         },
-        title: {
+        titleFr: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 255,
+        },
+        titleEn: {
           type: 'string',
           minLength: 1,
           maxLength: 255,

--- a/server/src/schemas/content.schema.ts
+++ b/server/src/schemas/content.schema.ts
@@ -6,16 +6,21 @@
     return {
       type: 'object',
       properties: {
-        content: {
+        contentFr: {
           type: 'string',
           minLength: 1},
           isPublished: {
           type: 'boolean',
           default: false, 
-          }
+          },
+        contentEn: {
+          type: 'string',
+          minLength: 1,
+        }
       },
       required: [
-        'content'
+        'contentFr',
+        'contentEn'
       ],
       additionalProperties: false,
     };
@@ -45,7 +50,11 @@
           type: 'string',
           format: 'uuid',
         },
-        content: {
+        contentFr: {
+          type: 'string',
+          minLength: 1,
+        },
+        contentEn: {
           type: 'string',
           minLength: 1,
         },

--- a/server/src/schemas/page.schema.ts
+++ b/server/src/schemas/page.schema.ts
@@ -6,7 +6,12 @@
     return {
       type: 'object',
       properties: {
-        title: {
+        titleFr: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 255,
+        },
+        titleEn: {
           type: 'string',
           minLength: 1,
           maxLength: 255,
@@ -17,7 +22,8 @@
         },
       },
       required: [
-        'title'
+        'titleFr',
+        'titleEn'
       ],
       additionalProperties: false,
     };
@@ -47,7 +53,12 @@
           type: 'string',
           format: 'uuid',
         },
-        title: {
+        titleFr: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 255,
+        },
+        titleEn: {
           type: 'string',
           minLength: 1,
           maxLength: 255,

--- a/server/src/schemas/picture.schema.ts
+++ b/server/src/schemas/picture.schema.ts
@@ -8,7 +8,11 @@ import { url } from "inspector";
       type: 'object',
       properties: {
        
-        description: {
+        descriptionFr: {
+          type: 'string',
+          maxLength: 500,
+        },
+        descriptionEn: {
           type: 'string',
           maxLength: 500,
         },
@@ -24,7 +28,8 @@ import { url } from "inspector";
       required: [
         
         'albumId',
-        'description'
+        'descriptionFr',
+        'descriptionEn',
       ],
       additionalProperties: false,
     };
@@ -58,7 +63,11 @@ import { url } from "inspector";
           type: 'string',
           format: 'uri',
         },
-        description: {
+        descriptionFr: {
+          type: 'string',
+          maxLength: 500,
+        },
+        descriptionEn: {
           type: 'string',
           maxLength: 500,
         },

--- a/server/src/specs/fixtures/album.fixture.ts
+++ b/server/src/specs/fixtures/album.fixture.ts
@@ -3,15 +3,17 @@
   
   
   interface AlbumOverrides {
-    title?: string;
+    titleFr?: string;
     isPublished?: boolean;
+    titleEn?: string;
   
   }
   
   export const createAlbumFixture = async (overrides: AlbumOverrides = {}) => {
   
     const album = await Album.create({
-      title: overrides.title || "Default Album Title",
+      titleFr: overrides.titleFr || "Default Album TitleFr",
+      titleEn: overrides.titleEn || "Default Album TitleEn",
       isPublished: overrides.isPublished !== undefined ? overrides.isPublished : true,
     });
   

--- a/server/src/specs/fixtures/blog.fixture.ts
+++ b/server/src/specs/fixtures/blog.fixture.ts
@@ -3,7 +3,8 @@
   
   
   interface BlogOverrides {
-    title?: string;   
+    titleFr?: string;
+    titleEn?: string;   
     isPublished?: boolean;
   
   }
@@ -11,7 +12,8 @@
   export const createBlogFixture = async (overrides: BlogOverrides = {}) => {
   
     const blog = await Blog.create({
-      title: overrides.title || "Test Blog Title",
+      titleFr: overrides.titleFr || "Test Blog TitleFr",
+      titleEn: overrides.titleEn || "Test Blog TitleEn",
       isPublished: overrides.isPublished !== undefined ? overrides.isPublished : true,
     });
   

--- a/server/src/specs/fixtures/content.fixture.ts
+++ b/server/src/specs/fixtures/content.fixture.ts
@@ -3,7 +3,8 @@
   
   
   interface ContentOverrides {
-    content?: string;
+    contentFr?: string;
+    contentEn?: string;
     isPublished?: boolean;
   
   }
@@ -11,7 +12,8 @@
   export const createContentFixture = async (overrides: ContentOverrides = {}) => {
   
     const content = await Content.create({
-      content: overrides.content || "Test Content",
+      contentFr: overrides.contentFr || "Test ContentFr",
+      contentEn: overrides.contentEn || "Test ContentEn",
       isPublished: overrides.isPublished !== undefined ? overrides.isPublished : true,
     });
   

--- a/server/src/specs/fixtures/page.fixture.ts
+++ b/server/src/specs/fixtures/page.fixture.ts
@@ -3,7 +3,8 @@
   
   
   interface PageOverrides {
-    title?: string;   
+    titleFr?: string;
+    titleEn?: string;   
     isPublished?: boolean;
   
   }
@@ -11,7 +12,8 @@
   export const createPageFixture = async (overrides: PageOverrides = {}) => {
   
     const page = await Page.create({
-      title: overrides.title || "Test Page Title",
+      titleFr: overrides.titleFr || "Test Page TitleFr",
+      titleEn: overrides.titleEn || "Test Page TitleEn",
       isPublished: overrides.isPublished !== undefined ? overrides.isPublished : true,
     });
   

--- a/server/src/specs/routes/album.routes.test.ts
+++ b/server/src/specs/routes/album.routes.test.ts
@@ -24,7 +24,8 @@
   
       const data = {
         
-        title: faker.lorem.sentence(),
+        titleFr: faker.lorem.sentence(),
+        titleEn: faker.lorem.sentence(),
         isPublished: false, 
       };
   
@@ -128,7 +129,7 @@
       const updateData = {
         id: album.id,
         
-        title: faker.lorem.sentence(),
+        titleFr: faker.lorem.sentence(),
         isPublished: true,
       };
   

--- a/server/src/specs/routes/blog.routes.test.ts
+++ b/server/src/specs/routes/blog.routes.test.ts
@@ -25,7 +25,8 @@
   
       const data = {
         
-        title: faker.lorem.sentence(),
+        titleFr: faker.lorem.sentence(),
+        titleEn: faker.lorem.sentence(),
         isPublished: faker.datatype.boolean(),
       };
   
@@ -142,7 +143,7 @@
       const updateData = {
         id: blog.id,
         
-        title: faker.lorem.sentence(),
+        titleFr: faker.lorem.sentence(),
         isPublished: faker.datatype.boolean(),
       };
   

--- a/server/src/specs/routes/content.routes.test.ts
+++ b/server/src/specs/routes/content.routes.test.ts
@@ -24,7 +24,8 @@
       
   
       const data = {
-        content: faker.lorem.paragraph(),
+        contentFr: faker.lorem.paragraph(),
+        contentEn: faker.lorem.paragraph(),
       };
   
       const response = await request(app)
@@ -136,7 +137,7 @@
       const updateData = {
         id: content.id,
         
-        content: faker.lorem.paragraph(),
+        contentFr: faker.lorem.paragraph(),
         isPublished: true,
       };
   

--- a/server/src/specs/routes/page.routes.test.ts
+++ b/server/src/specs/routes/page.routes.test.ts
@@ -24,7 +24,8 @@
   
       const data = {
         
-        title: faker.lorem.sentence(),
+        titleFr: faker.lorem.sentence(),
+        titleEn: faker.lorem.sentence(),
         isPublished: faker.datatype.boolean(),
       };
   
@@ -51,7 +52,8 @@
       expect(Array.isArray(response.body)).toBe(true);
       expect(response.body.length).toEqual(1);
       expect(response.body[0]).toHaveProperty("id");
-      expect(response.body[0]).toHaveProperty("title");
+      expect(response.body[0]).toHaveProperty("titleFr");
+      expect(response.body[0]).toHaveProperty("titleEn");
       expect(response.body[0]).toHaveProperty("isPublished");
       expect(response.body[0].isPublished).toBe(true);
 
@@ -144,7 +146,7 @@
       const updateData = {
         id: page.id,
         
-        title: faker.lorem.sentence(),
+        titleFr: faker.lorem.sentence(),
         isPublished: faker.datatype.boolean(),
       };
   

--- a/server/src/specs/routes/picture.routes.test.ts
+++ b/server/src/specs/routes/picture.routes.test.ts
@@ -25,7 +25,8 @@
   
       const data = {
         albumId: album.id.toString(),
-        description: faker.lorem.sentence(),        
+        descriptionFr: faker.lorem.sentence(),   
+        descriptionEn: faker.lorem.sentence(),     
         
       };
   
@@ -122,7 +123,7 @@ it("should get all pictures for management", async () => {
       const updateData = {
         id: picture.id,
         albumId: album.id.toString(),
-        description: faker.lorem.sentence(),
+        descriptionFr: faker.lorem.sentence(),
         isPublished: true,
       };
   


### PR DESCRIPTION
This pull request introduces multilingual support for titles, descriptions, and content across various entities in both the client and server sides of the application. The changes involve updating models, schemas, services, fixtures, and tests to accommodate separate fields for French and English versions of these properties.

### Client-side Changes

* **Service Interfaces Updated**:
  - Added `titleFr` and `titleEn` fields to `Album`, `Blog`, and `Page` interfaces. [[1]](diffhunk://#diff-95c295fb6bde662309c8fcabbc8b395bbfaea7cca289fd12284789f567108504L5-R6) [[2]](diffhunk://#diff-0081e5cdcf751838c2e82bfe4d798880cc44753b8752d0ad1e5b4832f69a6ff4L5-R6) [[3]](diffhunk://#diff-8783dec16bdfa84557169710009f60f89abeb7f249ff39d72dcb5fe671a77a70L5-R6)
  - Added `contentFr` and `contentEn` fields to `Content` interface.
  - Added `descriptionFr` and `descriptionEn` fields to `Picture` interface.

### Server-side Changes

#### Models
* **Database Models Updated**:
  - Added `titleFr` and `titleEn` fields to `Album`, `Blog`, and `Page` models. [[1]](diffhunk://#diff-8c4b67c0789ca588ea3ff25e9edb4a74fa4db40deec41be3f6df6a9701859e77L9-R10) [[2]](diffhunk://#diff-2a1702b8badb9babd986ca0890a23148844a9eb2eea72c68f04134e405a0087bL9-R10) [[3]](diffhunk://#diff-d3529d29ec7a038a8e26851b6d72e650cd1e391e3d83a620b23d880d4d3d1e69L9-R10)
  - Added `contentFr` and `contentEn` fields to `Content` model.
  - Added `descriptionFr` and `descriptionEn` fields to `Picture` model with validation for maximum length.

#### Schemas
* **Validation Schemas Updated**:
  - Updated schemas to include `titleFr` and `titleEn` for `Album`, `Blog`, and `Page`. [[1]](diffhunk://#diff-ef4a022b13c4a1e3f13d56dc72e19f86c42dc729cc83f6d209a6544d072d6d50L10-R15) [[2]](diffhunk://#diff-2b4ccd15c955173487a1b07dcec55c0cbdf93a0d3d7cd37525517433ccbeb00aL9-R14) [[3]](diffhunk://#diff-f02514302bb1ec4338b9073feb9dd6a73b0052ad36b4b308893b03900cc24ea2L9-R14)
  - Updated schemas to include `contentFr` and `contentEn` for `Content`.
  - Updated schemas to include `descriptionFr` and `descriptionEn` for `Picture`.

#### Fixtures
* **Test Fixtures Updated**:
  - Added support for `titleFr` and `titleEn` in `Album`, `Blog`, and `Page` fixtures. [[1]](diffhunk://#diff-78345f29c560c68318b401e43ae3364ce9603977974e529c2d6809abb94713cfL6-R16) [[2]](diffhunk://#diff-d433c02263dc684157fce84cab3f81b2a76a72e2eeb9f857271bc6d5f155d06eL6-R16) [[3]](diffhunk://#diff-1f0099aae7ac568a13746d0de6b42fdc590ac337dd15c42808e6f0199b027cb5L6-R16)
  - Added support for `contentFr` and `contentEn` in `Content` fixture.

#### Tests
* **Route Tests Updated**:
  - Modified `album.routes.test.ts` to test `titleFr` and `titleEn` fields in create and update operations. [[1]](diffhunk://#diff-53b7c1bffa566b31e0637fdc77b02cd0b8d5d72ae18c1cf59c03ece77ff757faL27-R28) [[2]](diffhunk://#diff-53b7c1bffa566b31e0637fdc77b02cd0b8d5d72ae18c1cf59c03ece77ff757faL131-R132)